### PR TITLE
When a pattern variable is defined on only one side of a disjunction,

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Match"
 uuid = "7eb4fadd-790c-5f42-8a69-bfa0b872bfbf"
-version = "2.0.1"
+version = "2.1.0"
 authors = ["Neal Gafter <neal@gafter.com>", "Kevin Squire <kevin.squire@gmail.com>"]
 
 [deps]

--- a/src/bound_pattern.jl
+++ b/src/bound_pattern.jl
@@ -56,6 +56,9 @@ struct BoundExpression
     function BoundExpression(location::LineNumberNode,
         source::Any,
         assignments::ImmutableDict{Symbol, Symbol} = ImmutableDict{Symbol, Symbol}())
+        for (k, v) in assignments
+            @assert v !== unusable_variable
+        end
         new(location, source, assignments)
     end
 end

--- a/src/lowering.jl
+++ b/src/lowering.jl
@@ -6,7 +6,7 @@ pattern_matches_value(r::Regex, s::AbstractString) = occursin(r, s)
 
 function assignments(assigned::ImmutableDict{Symbol, Symbol})
     # produce a list of assignments to be splatted into the caller
-    return (:($patvar = $resultsym) for (patvar, resultsym) in assigned)
+    return (:($patvar = $resultsym) for (patvar, resultsym) in assigned if resultsym !== unusable_variable)
 end
 
 function code(e::BoundExpression)

--- a/test/matchtests.jl
+++ b/test/matchtests.jl
@@ -330,4 +330,84 @@ end
     @test test_interp([1, 2]) == :(1 + 2)
 end
 
+@testset "handling of variables defined on one side (only) of a disjunction 1" begin
+
+    # It is an error to use a variable name after it has previously been used in the
+    # enclosing pattern on one side (only) of a disjunction.  If you run into this error
+    # you must rename the second variable to use a distinct name so that it is clear
+    # that it is not a reference to the previously named variable.
+
+    let line = (@__LINE__) + 3, file=(@__FILE__)
+        try
+            @eval @match (2, 1) begin
+                ((1|y), y) => true
+                _ => false
+            end
+            @test false
+        catch ex
+            @test ex isa LoadError
+            e = ex.error
+            @test e isa ErrorException
+            @test e.msg == "$file:$line: May not reuse variable name `y` after it has previously been used on only one side of a disjunction."
+        end
+    end
+
+end
+
+@testset "handling of variables defined on one side (only) of a disjunction 2" begin
+
+    # It is an error to use a variable name after it has previously been used in the
+    # enclosing pattern on one side (only) of a disjunction.  If you run into this error
+    # you must rename the second variable to use a distinct name so that it is clear
+    # that it is not a reference to the previously named variable.
+
+    let line = (@__LINE__) + 3, file=(@__FILE__)
+        try
+            @eval @match (2, 1) begin
+                ((1|y|y), y) => true
+                _ => false
+            end
+            @test false
+        catch ex
+            @test ex isa LoadError
+            e = ex.error
+            @test e isa ErrorException
+            @test e.msg == "$file:$line: May not reuse variable name `y` after it has previously been used on only one side of a disjunction."
+        end
+    end
+
+end
+
+@testset "handling of variables defined on one side (only) of a disjunction 3" begin
+
+    # It is an error to use a variable name after it has previously been used in the
+    # enclosing pattern on one side (only) of a disjunction.  If you run into this error
+    # you must rename the second variable to use a distinct name so that it is clear
+    # that it is not a reference to the previously named variable.
+
+    let line = (@__LINE__) + 3, file=(@__FILE__)
+        try
+            @eval @match 1 begin
+                1|y => y
+                _ => false
+            end
+            @test false
+        catch ex
+            @test ex isa LoadError
+            e = ex.error
+            @test e isa ErrorException
+            @test e.msg == "$file:$line: The pattern variable `y` cannot be used because it was defined on only one side of a disjunction."
+        end
+    end
+
+end
+
+@testset "handling of variables defined on one side (only) of a disjunction 4" begin
+
+    @test @match 1 begin
+        1|y => true
+    end
+
+end
+
 end

--- a/test/rematch.jl
+++ b/test/rematch.jl
@@ -371,10 +371,13 @@ end
         (1, a && (1,b)) => (a,b)
     end) == ((2,3),3)
 
-    # only vars that exist in all branches can be accessed
-    @test_throws UndefVarError(:y) @match (1,(2,3)) begin
-      (1, (x,:nope) || (2,y)) => y
-    end
+    # Only pattern variables that exist in all branches can be accessed.
+    # This is now a bind-time error. A test for that is in
+    # matchtests.jl.
+    #
+    # @test_throws UndefVarError(:y) @match (1,(2,3)) begin
+    #   (1, (x,:nope) || (2,y)) => y
+    # end
 end
 
 @testset "Splats" begin

--- a/test/rematch.jl
+++ b/test/rematch.jl
@@ -76,7 +76,8 @@ file = Symbol(@__FILE__)
                 @test ex isa LoadError
                 e = ex.error
                 @test e isa ErrorException
-                @test e.msg == "$file:$line: Could not bind `Unknown` as a type (due to `UndefVarError(:Unknown)`)."
+                err = (VERSION < v"1.11-") ? UndefVarError(:Unknown) : UndefVarError(:Unknown, @__MODULE__)
+                @test e.msg == "$file:$line: Could not bind `Unknown` as a type (due to `$err`)."
             end
         end
     end
@@ -454,7 +455,8 @@ end
     end
 
     # nested guards can't use later bindings
-    @test_throws UndefVarError(:y) @match [2,1] begin
+    err = (VERSION < v"1.11-") ? UndefVarError(:y) : UndefVarError(:y, @__MODULE__)
+    @test_throws err @match [2,1] begin
       [x where y > x, y ] => (x,y)
     end
 end


### PR DESCRIPTION
When a pattern variable is defined on only one side of a disjunction,
it is now an error to use it again later in the pattern, or in a value expression. The reason is that the semantics are too confusing. If you get this error, just rename the pattern variable to avoid the conflict, or use a wildcard instead.

This is technically a breaking change, but I'm guessing that it will occur only rarely in practice. Therefore I am only bumping the minor version number.

Fixes #99