### PR TITLE
Defer generating labels in the automaton to prevent duplicate labels being generated

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Match"
 uuid = "7eb4fadd-790c-5f42-8a69-bfa0b872bfbf"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Neal Gafter <neal@gafter.com>", "Kevin Squire <kevin.squire@gmail.com>"]
 
 [deps]

--- a/src/lowering.jl
+++ b/src/lowering.jl
@@ -10,7 +10,7 @@ function assignments(assigned::ImmutableDict{Symbol, Symbol})
 end
 
 function code(e::BoundExpression)
-    value = Expr(:block, e.location, source(e))
+    value = Expr(:block, e.location, code_for_expression(source(e)))
     assignments = Expr(:block, (:($k = $v) for (k, v) in e.assignments)...)
     return Expr(:let, assignments, value)
 end

--- a/src/match_cases_opt.jl
+++ b/src/match_cases_opt.jl
@@ -301,10 +301,12 @@ function remove(action::BoundIsMatchTestPattern, action_result::Bool, pattern::B
     # As a special case, if the input variable is of type Bool, then we know that true and false
     # are the only values it can hold.
     type = get!(() -> Any, binder.types, action.input)
-    if type == Bool && action.bound_expression.source isa Bool && pattern.bound_expression.source isa Bool
-        @assert action.bound_expression.source != pattern.bound_expression.source # because we already checked for equality
+    action_src = source(action.bound_expression)
+    pattern_src = source(pattern.bound_expression)
+    if type == Bool && action_src isa Bool && pattern_src isa Bool
+        @assert action_src != pattern_src # because we already checked for equality
         # If the one succeeded, then the other one fails
-        return BoundBoolPattern(loc(pattern), source(pattern), !action_result)
+        return BoundBoolPattern(loc(pattern), pattern_src, !action_result)
     end
 
     return pattern

--- a/src/match_return.jl
+++ b/src/match_return.jl
@@ -76,28 +76,23 @@ end
 # in which `MatchFailure` is a possible result.
 #
 function adjust_case_for_return_macro(__module__, location, pattern, result, predeclared_temps)
-    value = nothing
-    label = nothing
     found_early_exit::Bool = false
-    function make_label()
-        if !found_early_exit
-            value = gensym("value")
-            label = gensym("label")
-            found_early_exit = true
-        end
-    end
+
+    # Check for the presence of early exit macros @match_return and @match_fail
     function adjust_top(p)
         is_expr(p, :macrocall) || return p
         if length(p.args) == 3 &&
             (p.args[1] == :var"@match_return"  || p.args[1] == Expr(:., Symbol(string(@__MODULE__)), QuoteNode(:var"@match_return")))
             # :(@match_return e) -> :($value = $e; @goto $label)
-            make_label()
-            return Expr(:block, p.args[2], :($value = $(p.args[3])), :(@goto $label))
+            found_early_exit = true
+            # expansion of the result will be done later by ExpressionRequiringAdjustmentForReturnMacro 
+            return p
         elseif length(p.args) == 2 &&
             (p.args[1] == :var"@match_fail"  || p.args[1] == Expr(:., Symbol(string(@__MODULE__)), QuoteNode(:var"@match_fail")))
             # :(@match_fail) -> :($value = $MatchFaulure; @goto $label)
-            make_label()
-            return Expr(:block, p.args[2], :($value = $MatchFailure), :(@goto $label))
+            found_early_exit = true
+            # expansion of the result will be done later by ExpressionRequiringAdjustmentForReturnMacro 
+            return p
         elseif length(p.args) == 4 &&
             (p.args[1] == :var"@match" || p.args[1] == Expr(:., Symbol(string(@__MODULE__)), QuoteNode(:var"@match")))
             # Nested uses of @match should be treated as independent
@@ -112,12 +107,59 @@ function adjust_case_for_return_macro(__module__, location, pattern, result, pre
     if found_early_exit
         # Since we found an early exit, we need to predeclare the temp to ensure
         # it is in scope both for where it is written and in the constructed where clause.
-        push!(predeclared_temps, value)
-        where_expr = Expr(:block, location, :($value = $rewritten_result), :(@label $label), :($value !== $MatchFailure))
+        value_symbol = gensym("value")
+        push!(predeclared_temps, value_symbol)
+        
+        # Defer generation of the label and branch, so we get a unique label in case it needs to be generated more than once.
+        where_expr = where_expression_requiring_adjustment_for_return_macro(value_symbol, location, rewritten_result)
         new_pattern = :($pattern where $where_expr)
-        new_result = value
+        new_result = value_symbol
         (new_pattern, new_result)
     else
         (pattern, rewritten_result)
     end
+end
+
+const marker_for_where_expression_requiring_adjustment_for_return_macro =
+    :where_expression_requiring_adjustment_for_return_macro
+
+# We defer generating the code for the where clause with the label, because
+# the state machine may require it to be generated more than once, and each
+# generated version must use a fresh new label to avoid a duplicate label
+# in the generated code.
+function where_expression_requiring_adjustment_for_return_macro(
+    value_symbol::Symbol,
+    location,
+    expression_containing_macro)
+    Expr(marker_for_where_expression_requiring_adjustment_for_return_macro,
+         value_symbol, location, expression_containing_macro)
+end
+
+# See doc for where_expression_requiring_adjustment_for_return_macro, above
+code_for_expression(x) = x
+function code_for_expression(x::Expr)
+    x.head == marker_for_where_expression_requiring_adjustment_for_return_macro || return x
+    value_symbol, location, expression_containing_macro = x.args
+    label = gensym("early_label")
+
+    function adjust_top(result)
+        is_expr(result, :macrocall) || return result
+        if length(result.args) == 3 &&
+            (result.args[1] == :var"@match_return" ||
+             result.args[1] == Expr(:., Symbol(string(@__MODULE__)), QuoteNode(:var"@match_return")))
+            # :(@match_return e) -> :($value = $e; @goto $label)
+            return Expr(:block, result.args[2], :($value_symbol = $(result.args[3])), :(@goto $label))
+        elseif length(result.args) == 2 &&
+            (result.args[1] == :var"@match_fail" ||
+             result.args[1] == Expr(:., Symbol(string(@__MODULE__)), QuoteNode(:var"@match_fail")))
+            # :(@match_fail) -> :($value = $MatchFaulure; @goto $label)
+            return Expr(:block, result.args[2], :($value_symbol = $MatchFailure), :(@goto $label))
+        else
+            return result 
+        end
+    end
+
+    rewritten_result = MacroTools.prewalk(adjust_top, expression_containing_macro)
+    Expr(:block, location, :($value_symbol = $rewritten_result),
+         :(@label $label), :($value_symbol !== $MatchFailure))
 end

--- a/test/match_return.jl
+++ b/test/match_return.jl
@@ -126,4 +126,20 @@ end
     end) == 2
 end
 
+foo(x) = x == 9
+@testset "Test for presence of bug https://github.com/JuliaServices/Match.jl/issues/102" begin
+    @test (@match Foo(1, 2) begin
+        Foo(_, _) where (foo(1) && foo(2)) => 15
+        Foo(_, _) where foo(7) =>
+            begin
+                if foo(9)
+                    @match_return 16
+                end
+                17
+            end
+        Foo(_, _) where (foo(1) && foo(3)) => 18
+        _ => 43
+    end) == 43
+end
+
 end


### PR DESCRIPTION
The generated code for `@match_return` and `@match_fail` produce labels in the generated code. However, the code for patterns may be repeated, and code that contains these constructs is rewritten as part of the pattern. Consequently, these constructs can end up generating code with duplicate labels. To prevent that, we defer generating the label until the code is generated, so each copy of it will get a distinct label.

The first commit makes a couple of changes that are just refactorings to simplify things.
The second commit fixes the bug.
You will probably find it easier to review the two commits separately.

Fixes: #102 
