### PR TITLE
Fix #106 by removing accidental quadratic perf.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Match"
 uuid = "7eb4fadd-790c-5f42-8a69-bfa0b872bfbf"
-version = "2.1.1"
+version = "2.1.2"
 authors = ["Neal Gafter <neal@gafter.com>", "Kevin Squire <kevin.squire@gmail.com>"]
 
 [deps]

--- a/src/match_cases_opt.jl
+++ b/src/match_cases_opt.jl
@@ -156,7 +156,7 @@ end
 #
 function build_deduplicated_automaton(location::LineNumberNode, mod::Module, value, body)
     entry, predeclared_temps, binder = build_automaton(location::LineNumberNode, mod::Module, value, body)
-    top_down_nodes = deduplicate_automaton(entry, binder)
+    top_down_nodes = deduplicate_automaton(entry)
     return top_down_nodes, predeclared_temps, binder
 end
 
@@ -466,7 +466,7 @@ function handle_match_dump_verbose(__source__, __module__, io, value, body)
         # print the dump of the decision automaton before deduplication
         $dumpall($io, $top_down_nodes, $binder, true)
         # but return the count of deduplicated nodes.
-        $length($deduplicate_automaton($entry, $binder))
+        $length($deduplicate_automaton($entry))
     end)
 end
 

--- a/test/coverage.jl
+++ b/test/coverage.jl
@@ -550,4 +550,11 @@ end # of automaton
         end) == 2
         @test @__match__(1, 1 => 2) == 2
     end
+
+    @testset "Test trivial conditions" begin
+        @test (@__match__ 1 begin
+            _ => 2
+        end) == 2
+        @test @__match__(1, _ => 2) == 2
+    end
 end # @testset "Tests that add code coverage"

--- a/test/rematch2.jl
+++ b/test/rematch2.jl
@@ -341,7 +341,7 @@ end
     function f2(a, b, c, d, e, f, g, h)
         # For reference we use the brute-force implementation of pattern-matching that just
         # performs the tests sequentially, like writing an if-elseif-else chain.
-        Match.@match (a, b, c, d, e, f, g, h) begin
+        Match.@__match__ (a, b, c, d, e, f, g, h) begin
             (a, b, c, d, e, f, g, h) where (!(!((!a || !b) && (c || !d)) || !(!e || f) && (g || h))) => 1
             (a, b, c, d, e, f, g, h) where (!((!a || b) && (c || d) || (e || !f) && (!g || !h))) => 2
             (a, b, c, d, e, f, g, h) where (!((a || b) && !(!c || !d) || !(!(!e || f) && !(g || !h)))) => 3


### PR DESCRIPTION
This removes accidental quadratic perf (in the number of states) noted in https://github.com/JuliaServices/Match.jl/issues/106#issuecomment-2465875041

I wrote a simple program (below) to exercise the relevant code. I ran it on the `main` branch and this branch.

Before this change it prints:
```
elapsed = 39.548720291
```

After this change it prints:
```
elapsed = 5.89339075
```

I don't know a reasonable way to add a test for this, but the test I ran by hand to get the above results was crafted specifically to produce a relatively larger state machine:

```julia
module B

using Random
using Match

r = Xoshiro(0)

function f(x)
    return rand(r) < 0.5
end

start_time = time_ns()

function g(x)
    @match x begin
        _, if !f(34) && f(30) && !f(25) end => 1
        _, if !f(4) && !f(14) && f(25) end => 2
        _, if !f(16) && !f(0) && !f(42) end => 3
        _, if f(1) && !f(23) && !f(5) end => 4
        _, if !f(39) && f(12) && f(44) end => 5
        _, if f(49) && !f(2) && f(22) end => 6
        _, if !f(43) && !f(33) && !f(45) end => 7
        _, if f(10) && !f(6) && f(26) end => 8
        _, if f(29) && f(34) && f(49) end => 9
        _, if f(45) && !f(20) && f(5) end => 10
        _, if !f(38) && !f(26) && f(34) end => 11
        _, if f(18) && !f(8) && f(0) end => 12
        _, if f(31) && f(30) && f(1) end => 13
        _, if f(17) && f(49) && f(20) end => 14
        _, if !f(20) && !f(19) && !f(9) end => 15
        _, if !f(2) && !f(18) && !f(10) end => 16
        _, if !f(12) && f(22) && !f(43) end => 17
        _, if !f(13) && f(20) && !f(36) end => 18
        _, if f(30) && f(49) && !f(44) end => 19
        _, if !f(21) && !f(37) && f(9) end => 20
        _, if !f(11) && !f(20) && !f(30) end => 21
        _, if !f(30) && f(9) && f(36) end => 22
        _, if f(42) && !f(36) && !f(45) end => 23
        _, if f(31) && !f(26) && f(34) end => 24
        _ => -1
    end
end

println(g(1))

end_time = time_ns()
elapsed = (end_time - start_time) / 1e9
println("elapsed = $elapsed")

end
```
