### PR TITLE
Simplify handling of the early exit macros.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,7 +2,7 @@
 
 The Match.jl package is licensed under the MIT Expat License:
 
-Copyright (c) 2013-2023: Neal Gafter, Kevin Squire, RelationalAI, Inc, and contributors.
+Copyright (c) 2013-2025: Neal Gafter, Kevin Squire, RelationalAI, Inc, and contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Match"
 uuid = "7eb4fadd-790c-5f42-8a69-bfa0b872bfbf"
-version = "2.4.0"
+version = "2.4.1"
 authors = ["Neal Gafter <neal@gafter.com>", "Nate Nystrom <nate.nystrom@relational.ai>", "Kevin Squire <kevin.squire@gmail.com>"]
 
 [deps]

--- a/src/match_return.jl
+++ b/src/match_return.jl
@@ -75,7 +75,7 @@ function adjust_case_for_return_macro(__module__, location, pattern, result, pre
     found_early_exit::Bool = false
 
     # Check for the presence of early exit macros
-    function adjust_top(p)
+    function check_for_early_exit(p)
         if !found_early_exit && is_expr(p, :call)
             f = p.args[1]
             if is_early_exit(f)
@@ -84,7 +84,7 @@ function adjust_case_for_return_macro(__module__, location, pattern, result, pre
         end
         return p
     end
-    MacroTools.postwalk(adjust_top, result)
+    MacroTools.postwalk(check_for_early_exit, result)
 
     if found_early_exit
         # Since we found an early exit, we need to predeclare the temp to ensure

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,5 @@
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-ReTest = "e0db7c4e-2690-44b9-bad6-7687da720f89"
 Match = "7eb4fadd-790c-5f42-8a69-bfa0b872bfbf"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/match_return.jl
+++ b/test/match_return.jl
@@ -33,11 +33,9 @@ file = Symbol(@__FILE__)
     let line = 0
         try
             line = (@__LINE__) + 1
-            @eval @match_return 2
+            @match_return 2
             @test false
-        catch ex
-            @test ex isa LoadError
-            e = ex.error
+        catch e
             @test e isa ErrorException
             @test e.msg == "$file:$line: @match_return may only be used within the value of a @match case."
         end
@@ -48,11 +46,9 @@ end
     let line = 0
         try
             line = (@__LINE__) + 1
-            @eval @match_fail
+            @match_fail
             @test false
-        catch ex
-            @test ex isa LoadError
-            e = ex.error
+        catch e
             @test e isa ErrorException
             @test e.msg == "$file:$line: @match_fail may only be used within the value of a @match case."
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ module Rematch2Tests
 
 using Match
 using Match: topological_sort, @__match__
-using ReTest
+using Test
 using Random
 using MacroTools: MacroTools
 
@@ -15,7 +15,5 @@ include("topological.jl")
 include("match_return.jl")
 include("test_ismatch.jl")
 include("matchtests.jl")
-
-retest(Rematch2Tests)
 
 end # module


### PR DESCRIPTION
This should address #123 as well, making the
strategy compatible with the early access version
of Julia 1.12.

Besides simplifying the handling of nested macros within `@match`, this fixes an incompatibility with the Julia 1.12 rewrite of the Julia macro implementation. The issue #123 has links to the Julia issues. We now use the "normal" recursive version of the macro expansion function, as the non-recursive version is what "caused" the error. The incompatibility might or might not be fixed in Julia before 1.12 is released, but with this change it doesn't matter. It works with all Julia versions equally well.

Testing against the Julia nightly version failed because the nightly breaks the `ReTest` package. I did test this by hand against the most recent 1.12 preview and it doesn't have the issue reported in #123.

Fixes #123